### PR TITLE
Add stage 2.1 validation log for API README

### DIFF
--- a/zoval_check.md
+++ b/zoval_check.md
@@ -1,0 +1,6 @@
+# ZO Validation Check
+
+| Документация | Тестовый файл | Результат теста | Соответствие примеров |
+| --- | --- | --- | --- |
+| docs/api/README.md | devref/gaps/zo/zodoctest/test_api_readme_validation.py | ✅ 9/9 тестов пройдено | Примеры Universal Pipeline и PRELOADED MACD из документации запускаются тестами `test_actual_macd_examples` и `test_universal_pipeline_example`; тестовый скрипт не покрывает вызов `macd_indicator.calculate(data)` перед использованием PRELOADED индикатора, но остальные шаги соответствуют документации. |
+


### PR DESCRIPTION
## Summary
- add zoval_check.md to capture validation status for docs/api/README.md
- document the associated test script and outstanding gap in test coverage

## Testing
- python devref/gaps/zo/zodoctest/test_api_readme_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68fdff11b5e083228720fca047e933a8