### PR TITLE
Improve zone analysis visualization entrypoint

### DIFF
--- a/docs/user_guide/zone_analysis.md
+++ b/docs/user_guide/zone_analysis.md
@@ -457,8 +457,32 @@ print(f"Гипотезы: {result.hypothesis_tests}")
 result.save('results/macd_zones.pkl')
 
 # Визуализация
-fig = result.visualize('overview')
+fig = result.visualize('overview', title='Price + Zones')
 fig.show()
+
+# Детальный разбор одной зоны (см. раздел «Визуализация» ниже)
+detail = result.visualize(
+    'detail',
+    zone_id=result.zones[0].zone_id,
+    context_bars=30,
+)
+detail.show()
+
+# Сравнение нескольких зон с выбором backend визуализатора
+comparison = result.visualize(
+    'comparison',
+    backend='matplotlib',
+    max_zones=4,
+)
+comparison.show()
+
+# Быстрый обзор статистики зон
+stats = result.visualize('statistics', title='Zone Statistics Summary')
+stats.show()
+
+> ⚠️ Визуализатор требует исходный ``DataFrame`` и список зон. Если
+> результат был сохранён без ``data`` или вы очистили ``result.zones``,
+> метод выдаст понятную ошибку с подсказкой.
 ```
 
 ### Модульное использование (только детекция)


### PR DESCRIPTION
## Summary
- add a lazy import and richer validation to `ZoneAnalysisResult.visualize`, including backend selection support
- refresh the zone analysis user guide with detailed visualization examples and usage notes

## Testing
- pytest tests/unit/test_zone_models.py -k visualize

------
https://chatgpt.com/codex/tasks/task_e_69009009553c83229e1e4773050a1b74