### PR TITLE
Add swing strategy presets and pipeline preset API

### DIFF
--- a/bquant/core/config.py
+++ b/bquant/core/config.py
@@ -1,12 +1,12 @@
-"""
-Configuration settings for the BQuant Project.
+"""Configuration settings for the BQuant Project.
 
 Universal configuration supporting multiple instruments, indicators, and analysis methods.
 """
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 # ============================================================================
 # PROJECT STRUCTURE
@@ -192,6 +192,51 @@ ANALYSIS_CONFIG = {
         'bootstrap_samples': 1000,
         'random_state': 42
     }
+}
+
+# ============================================================================
+# SWING STRATEGY PRESETS
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class SwingPreset:
+    """Grouping of parameter dictionaries for swing strategies."""
+
+    zigzag: Dict[str, Any]
+    find_peaks: Dict[str, Any]
+    pivot_points: Dict[str, Any]
+
+
+DEFAULT_SWING_PRESET = "default"
+
+SWING_PRESETS: Dict[str, SwingPreset] = {
+    DEFAULT_SWING_PRESET: SwingPreset(
+        zigzag={"legs": 10, "deviation": 0.05},
+        find_peaks={
+            "prominence": 0.015,
+            "distance": 5,
+            "min_amplitude_pct": 0.02,
+        },
+        pivot_points={
+            "left_bars": 2,
+            "right_bars": 2,
+            "min_amplitude_pct": 0.015,
+        },
+    ),
+    "narrow_zone": SwingPreset(
+        zigzag={"legs": 3, "deviation": 0.008},
+        find_peaks={
+            "prominence": 0.004,
+            "distance": 3,
+            "min_amplitude_pct": 0.006,
+        },
+        pivot_points={
+            "left_bars": 2,
+            "right_bars": 2,
+            "min_amplitude_pct": 0.006,
+        },
+    ),
 }
 
 # ============================================================================

--- a/tests/analysis/zones/test_swing_presets.py
+++ b/tests/analysis/zones/test_swing_presets.py
@@ -1,0 +1,74 @@
+"""Integration tests for swing parameter presets in the zone pipeline."""
+
+from statistics import mean
+
+import pytest
+
+from bquant.analysis.zones.pipeline import (
+    IndicatorConfig,
+    ZoneAnalysisConfig,
+    ZoneAnalysisPipeline,
+)
+from bquant.analysis.zones.detection import ZoneDetectionConfig
+from bquant.core.config import SWING_PRESETS
+from bquant.data.samples import get_sample_data
+
+
+@pytest.mark.slow
+def test_narrow_zone_applies_parameters():
+    df = get_sample_data("tv_xauusd_1h").set_index("time")
+
+    config = ZoneAnalysisConfig(
+        indicator=IndicatorConfig(
+            source="custom",
+            name="macd",
+            params={"fast_period": 12, "slow_period": 26, "signal_period": 9},
+        ),
+        zone_detection=ZoneDetectionConfig(
+            min_duration=2,
+            zone_types=["bull"],
+            rules={"indicator_col": "macd_hist"},
+            strategy_name="zero_crossing",
+        ),
+        perform_clustering=False,
+        n_clusters=3,
+        run_regression=False,
+        run_validation=False,
+    )
+
+    pipeline = ZoneAnalysisPipeline(config, enable_cache=False)
+    pipeline.with_swing_preset("narrow_zone")
+
+    preset = SWING_PRESETS["narrow_zone"]
+    zigzag = pipeline.swing_strategies["zigzag"]
+    assert zigzag.legs == preset.zigzag["legs"]
+    assert zigzag.deviation == pytest.approx(preset.zigzag["deviation"])
+
+    find_peaks = pipeline.swing_strategies["find_peaks"]
+    assert find_peaks.prominence == pytest.approx(preset.find_peaks["prominence"])
+    assert find_peaks.distance == preset.find_peaks["distance"]
+    assert find_peaks.min_amplitude_pct == pytest.approx(
+        preset.find_peaks["min_amplitude_pct"]
+    )
+
+    pivot_points = pipeline.swing_strategies["pivot_points"]
+    assert pivot_points.min_amplitude_pct == pytest.approx(
+        preset.pivot_points["min_amplitude_pct"]
+    )
+
+    result = pipeline.run(df)
+    bull_zones = [zone for zone in result.zones if zone.type == "bull"]
+    assert bull_zones, "Expected bull zones to be present"
+
+    swing_counts = [
+        zone.features["metadata"]["swing_metrics"]["num_swings"]
+        for zone in bull_zones
+    ]
+    density = mean(swing_counts)
+    assert density > 1.0
+
+    sample_metrics = bull_zones[0].features["metadata"]["swing_metrics"]
+    assert sample_metrics["strategy_params"]["legs"] == preset.zigzag["legs"]
+    assert sample_metrics["strategy_params"]["deviation"] == pytest.approx(
+        preset.zigzag["deviation"]
+    )


### PR DESCRIPTION
## Summary
- introduce reusable `SwingPreset` definitions for zigzag, find_peaks, and pivot_points strategies
- allow `ZoneAnalysisPipeline` and builder flows to apply named swing presets and keep configured strategy instances
- add a regression test that validates the narrow_zone preset parameters and swing density on sample data

## Testing
- pytest tests/analysis/zones/test_swing_presets.py::test_narrow_zone_applies_parameters

------
https://chatgpt.com/codex/tasks/task_e_690cadf35dd88322a0519f574768f630

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds reusable swing presets and enables applying them via pipeline/builder, with tests validating the narrow_zone preset.
> 
> - **Zones Pipeline (`bquant/analysis/zones/pipeline.py`)**:
>   - Adds swing preset machinery: `_SWING_CLASS_TO_NAME`, `swing_strategies` store, active strategy detection, and `_apply_swing_preset()` to instantiate strategies via `StrategyRegistry` and set `features.swing_strategy`.
>   - Public `with_swing_preset(name)` to apply named configurations; initializes with `DEFAULT_SWING_PRESET`.
> - **Config (`bquant/core/config.py`)**:
>   - Introduces `SwingPreset` dataclass, `DEFAULT_SWING_PRESET`, and `SWING_PRESETS` (includes `default` and `narrow_zone` parameter sets for `zigzag`, `find_peaks`, `pivot_points`).
> - **Builder (`ZoneAnalysisBuilder`)**:
>   - Adds `with_swing_preset(name)` and passes preset to `ZoneAnalysisPipeline` during `build()`.
> - **Tests**:
>   - Adds `tests/analysis/zones/test_swing_presets.py` verifying `narrow_zone` parameters propagate and increase swing density.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 321b7687cf9bb77dd320f98944a2657277198a1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->