### PR TITLE
Document swing presets and extend validation tooling

### DIFF
--- a/bquant/analysis/zones/pipeline.py
+++ b/bquant/analysis/zones/pipeline.py
@@ -12,7 +12,7 @@ Zone Analysis Pipeline
 """
 
 from dataclasses import dataclass, field, asdict
-from typing import Optional, Dict, Any, Literal, List
+from typing import Any, Dict, List, Literal, Optional
 import pandas as pd
 import hashlib
 import json
@@ -21,12 +21,88 @@ from bquant.indicators import IndicatorFactory
 from bquant.indicators.base import IndicatorResult
 from bquant.core.logging_config import get_logger
 from bquant.core.cache import get_cache_manager
+from bquant.core.config import DEFAULT_SWING_PRESET, SWING_PRESETS
+from .strategies.swing.thresholds import auto_swing_thresholds
 
 from .detection import ZoneDetectionRegistry, ZoneDetectionConfig
 from .analyzer import UniversalZoneAnalyzer
 from .models import ZoneInfo, ZoneAnalysisResult
+from .strategies.registry import StrategyRegistry
+from .strategies.swing import (
+    FindPeaksSwingStrategy,
+    PivotPointsSwingStrategy,
+    ZigZagSwingStrategy,
+)
 
 logger = get_logger(__name__)
+
+
+_SWING_CLASS_TO_NAME = {
+    ZigZagSwingStrategy: "zigzag",
+    FindPeaksSwingStrategy: "find_peaks",
+    PivotPointsSwingStrategy: "pivot_points",
+}
+
+
+class _AdaptiveSwingStrategy:
+    """Wrapper that re-computes swing thresholds per zone."""
+
+    def __init__(
+        self,
+        strategy_name: str,
+        base_params: Dict[str, Any],
+        *,
+        base_deviation: float,
+    ) -> None:
+        self.base_strategy_name = strategy_name
+        self._base_params = dict(base_params)
+        self._base_deviation = base_deviation
+        self._last_thresholds: Optional[Dict[str, float]] = None
+
+    def calculate(self, zone_data: pd.DataFrame):
+        thresholds = auto_swing_thresholds(
+            zone_data, base_deviation=self._base_deviation
+        )
+        params = dict(self._base_params)
+
+        if self.base_strategy_name == "zigzag":
+            params["deviation"] = thresholds.zigzag_deviation
+        elif self.base_strategy_name == "find_peaks":
+            params["prominence"] = thresholds.peak_prominence
+            params["min_amplitude_pct"] = thresholds.peak_prominence
+        elif self.base_strategy_name == "pivot_points":
+            params["min_amplitude_pct"] = thresholds.pivot_deviation
+
+        strategy = StrategyRegistry.get_swing_strategy(
+            self.base_strategy_name, **params
+        )
+        result = strategy.calculate(zone_data)
+        self._last_thresholds = {
+            "zigzag_deviation": thresholds.zigzag_deviation,
+            "peak_prominence": thresholds.peak_prominence,
+            "pivot_deviation": thresholds.pivot_deviation,
+        }
+        return result
+
+    def get_metadata(self) -> Dict[str, Any]:
+        metadata: Dict[str, Any] = {
+            "name": f"Adaptive{self.base_strategy_name}",
+            "description": "Swing strategy with auto-scaled thresholds",
+            "base_params": dict(self._base_params),
+            "auto_thresholds": True,
+            "base_deviation": self._base_deviation,
+        }
+        if self._last_thresholds:
+            metadata["last_thresholds"] = dict(self._last_thresholds)
+        return metadata
+
+    def config_hash(self) -> Dict[str, Any]:
+        """Configuration snapshot for adaptive threshold wrapper."""
+        return {
+            "base_strategy": self.base_strategy_name,
+            "base_params": dict(self._base_params),
+            "base_deviation": self._base_deviation,
+        }
 
 
 @dataclass
@@ -97,11 +173,14 @@ class ZoneAnalysisPipeline:
         result = pipeline.run(df)
     """
     
-    def __init__(self, 
+    def __init__(self,
                  config: ZoneAnalysisConfig,
                  zone_analyzer: Optional[UniversalZoneAnalyzer] = None,
                  enable_cache: bool = True,
-                 cache_ttl: int = 3600):
+                 cache_ttl: int = 3600,
+                 *,
+                 strategy_auto_thresholds: bool = False,
+                 auto_threshold_base_deviation: float = 0.01):
         """
         Инициализация pipeline.
         
@@ -117,11 +196,19 @@ class ZoneAnalysisPipeline:
         self.cache_ttl = cache_ttl
         self.cache_manager = get_cache_manager() if enable_cache else None
         self.logger = get_logger(__name__)
-    
+        self.swing_strategies: Dict[str, Any] = {}
+        self._active_swing_strategy: Optional[str] = self._detect_current_swing_strategy()
+        self._swing_preset: str = DEFAULT_SWING_PRESET
+        self.strategy_auto_thresholds = strategy_auto_thresholds
+        self._auto_threshold_base_deviation = auto_threshold_base_deviation
+        self._adaptive_swing_wrappers: Dict[str, _AdaptiveSwingStrategy] = {}
+        self._swing_preset_params: Dict[str, Dict[str, Any]] = {}
+        self._apply_swing_preset(DEFAULT_SWING_PRESET, update_active=False)
+
     def run(self, df: pd.DataFrame) -> ZoneAnalysisResult:
         """
         Выполнить полный pipeline анализа с кэшированием.
-        
+
         Если enable_cache=True, результат будет сохранен в кэш
         (память + диск) для повторного использования.
         
@@ -231,7 +318,7 @@ class ZoneAnalysisPipeline:
             run_regression=self.config.run_regression,
             run_validation=self.config.run_validation
         )
-    
+
     def _generate_cache_key(self, df: pd.DataFrame) -> str:
         """
         Генерация ключа кэша на основе конфигурации и данных.
@@ -252,7 +339,8 @@ class ZoneAnalysisPipeline:
             'perform_clustering': self.config.perform_clustering,
             'n_clusters': self.config.n_clusters,
             'run_regression': self.config.run_regression,
-            'run_validation': self.config.run_validation
+            'run_validation': self.config.run_validation,
+            'swing': self._serialize_swing_configuration(),
         }
         
         # ✅ v2.1: Check for non-serializable objects (e.g., lambda functions in conditions)
@@ -269,17 +357,36 @@ class ZoneAnalysisPipeline:
             else:
                 raise  # Re-raise other TypeError
         
-        config_hash = hashlib.md5(config_str.encode()).hexdigest()
+        config_hash = hashlib.sha256(config_str.encode()).hexdigest()
         
         # Собираем ключ
         key = f"zone_analysis_{data_hash}_{config_hash}"
-        
+
         return key
-    
+
+    def with_swing_preset(self, name: str) -> "ZoneAnalysisPipeline":
+        """Reconfigure swing strategies using a named preset."""
+
+        self._apply_swing_preset(name, update_active=True)
+        self._swing_preset = name
+        return self
+
+    def with_auto_swing_thresholds(
+        self, enable: bool = True, *, base_deviation: Optional[float] = None
+    ) -> "ZoneAnalysisPipeline":
+        """Toggle adaptive swing threshold calculation."""
+
+        self.strategy_auto_thresholds = enable
+        if base_deviation is not None:
+            self._auto_threshold_base_deviation = base_deviation
+        self._rebuild_adaptive_wrappers()
+        self._update_feature_swing_strategy()
+        return self
+
     def invalidate_cache(self, df: pd.DataFrame) -> None:
         """
         Инвалидировать кэш для конкретных данных.
-        
+
         Args:
             df: DataFrame для которого нужно инвалидировать кэш
         """
@@ -287,6 +394,114 @@ class ZoneAnalysisPipeline:
             cache_key = self._generate_cache_key(df)
             self.cache_manager.invalidate(cache_key)
             self.logger.info(f"Cache invalidated for key: {cache_key[:8]}...")
+
+    def _strategy_name_from_instance(self, strategy: Any) -> Optional[str]:
+        for cls, name in _SWING_CLASS_TO_NAME.items():
+            if isinstance(strategy, cls):
+                return name
+        base_name = getattr(strategy, "base_strategy_name", None)
+        if isinstance(base_name, str):
+            return base_name
+        return None
+
+    def _detect_current_swing_strategy(self) -> Optional[str]:
+        features = getattr(self.analyzer, "features", None)
+        if features is None:
+            return None
+        strategy = getattr(features, "swing_strategy", None)
+        return self._strategy_name_from_instance(strategy)
+
+    def _rebuild_adaptive_wrappers(self) -> None:
+        if not self.strategy_auto_thresholds:
+            self._adaptive_swing_wrappers = {}
+            return
+
+        wrappers: Dict[str, _AdaptiveSwingStrategy] = {}
+        for strategy_name, params in self._swing_preset_params.items():
+            wrappers[strategy_name] = _AdaptiveSwingStrategy(
+                strategy_name,
+                params,
+                base_deviation=self._auto_threshold_base_deviation,
+            )
+        self._adaptive_swing_wrappers = wrappers
+
+    def _update_feature_swing_strategy(self) -> None:
+        features = getattr(self.analyzer, "features", None)
+        if features is None:
+            return
+
+        if not self._active_swing_strategy:
+            return
+
+        if (
+            self.strategy_auto_thresholds
+            and self._active_swing_strategy in self._adaptive_swing_wrappers
+        ):
+            features.swing_strategy = self._adaptive_swing_wrappers[
+                self._active_swing_strategy
+            ]
+        elif self._active_swing_strategy in self.swing_strategies:
+            features.swing_strategy = self.swing_strategies[
+                self._active_swing_strategy
+            ]
+
+    def _serialize_swing_configuration(self) -> Dict[str, Any]:
+        """Return JSON-serializable snapshot of swing-related settings."""
+
+        strategies = {}
+        for name, strategy in sorted(self.swing_strategies.items()):
+            if hasattr(strategy, "config_hash"):
+                strategies[name] = strategy.config_hash()
+            else:
+                strategies[name] = {"repr": repr(strategy)}
+
+        preset_params = {
+            name: dict(params)
+            for name, params in sorted(self._swing_preset_params.items())
+        }
+
+        config: Dict[str, Any] = {
+            "preset": self._swing_preset,
+            "active_strategy": self._active_swing_strategy,
+            "strategy_auto_thresholds": self.strategy_auto_thresholds,
+            "auto_threshold_base_deviation": self._auto_threshold_base_deviation,
+            "strategies": strategies,
+            "preset_params": preset_params,
+        }
+
+        if self.strategy_auto_thresholds:
+            config["adaptive_wrappers"] = {
+                name: wrapper.config_hash()
+                for name, wrapper in sorted(self._adaptive_swing_wrappers.items())
+            }
+
+        return config
+
+    def _apply_swing_preset(self, name: str, *, update_active: bool) -> None:
+        if name not in SWING_PRESETS:
+            raise KeyError(f"Unknown swing preset: {name}")
+
+        preset = SWING_PRESETS[name]
+        preset_values = {
+            "zigzag": dict(preset.zigzag),
+            "find_peaks": dict(preset.find_peaks),
+            "pivot_points": dict(preset.pivot_points),
+        }
+        self._swing_preset_params = {key: dict(value) for key, value in preset_values.items()}
+
+        strategies: Dict[str, Any] = {}
+        for strategy_name, params in preset_values.items():
+            strategies[strategy_name] = StrategyRegistry.get_swing_strategy(
+                strategy_name, **params
+            )
+
+        self.swing_strategies = strategies
+        self._rebuild_adaptive_wrappers()
+
+        if update_active or self._active_swing_strategy is None:
+            self._active_swing_strategy = self._detect_current_swing_strategy()
+
+        self._update_feature_swing_strategy()
 
 
 class ZoneAnalysisBuilder:
@@ -328,6 +543,8 @@ class ZoneAnalysisBuilder:
         self._divergence_strategy: Optional[str] = None
         self._volatility_strategy: Optional[str] = None
         self._volume_strategy: Optional[str] = None
+        self._swing_preset: Optional[str] = None
+        self._auto_swing_thresholds = False
         self.logger = get_logger(__name__)
     
     def with_indicator(self, 
@@ -492,8 +709,22 @@ class ZoneAnalysisBuilder:
         self._volatility_strategy = volatility
         self._volume_strategy = volume
         return self
-    
-    def with_cache(self, 
+
+    def with_swing_preset(self, name: str) -> 'ZoneAnalysisBuilder':
+        """Specify swing strategy preset to apply before execution."""
+
+        self._swing_preset = name
+        return self
+
+    def with_auto_swing_thresholds(
+        self, enable: bool = True
+    ) -> 'ZoneAnalysisBuilder':
+        """Enable adaptive thresholds for swing strategies."""
+
+        self._auto_swing_thresholds = enable
+        return self
+
+    def with_cache(self,
                    enable: bool = True,
                    ttl: int = 3600) -> 'ZoneAnalysisBuilder':
         """
@@ -578,8 +809,13 @@ class ZoneAnalysisBuilder:
             config,
             zone_analyzer=custom_analyzer,  # ✅ v2.1: Pass custom analyzer
             enable_cache=self._enable_cache,
-            cache_ttl=self._cache_ttl
+            cache_ttl=self._cache_ttl,
+            strategy_auto_thresholds=self._auto_swing_thresholds,
         )
+        if self._swing_preset is not None:
+            pipeline.with_swing_preset(self._swing_preset)
+        if self._auto_swing_thresholds:
+            pipeline.with_auto_swing_thresholds(True)
         return pipeline.run(self.data)
 
 

--- a/bquant/analysis/zones/strategies/base.py
+++ b/bquant/analysis/zones/strategies/base.py
@@ -173,10 +173,10 @@ class SwingMetrics:
 class SwingCalculationStrategy(Protocol):
     """
     Protocol for swing detection algorithms.
-    
+
     Implementations must provide calculate_swings() and get_metadata() methods.
     """
-    
+
     def calculate_swings(self, zone_data: pd.DataFrame) -> SwingMetrics:
         """
         Calculate swing metrics.
@@ -191,6 +191,10 @@ class SwingCalculationStrategy(Protocol):
     
     def get_metadata(self) -> Dict[str, Any]:
         """Strategy metadata for logging and traceability."""
+        ...
+
+    def config_hash(self) -> Dict[str, Any]:
+        """Configuration snapshot used for cache key generation."""
         ...
 
 

--- a/bquant/analysis/zones/strategies/swing/find_peaks.py
+++ b/bquant/analysis/zones/strategies/swing/find_peaks.py
@@ -352,3 +352,11 @@ class FindPeaksSwingStrategy:
             ]
         }
 
+    def config_hash(self) -> Dict[str, Any]:
+        """Return configuration parameters for cache key generation."""
+        return {
+            'prominence': self.prominence,
+            'distance': self.distance,
+            'min_amplitude_pct': self.min_amplitude_pct
+        }
+

--- a/bquant/analysis/zones/strategies/swing/pivot_points.py
+++ b/bquant/analysis/zones/strategies/swing/pivot_points.py
@@ -385,3 +385,11 @@ class PivotPointsSwingStrategy:
             ]
         }
 
+    def config_hash(self) -> Dict[str, Any]:
+        """Return configuration parameters for cache key generation."""
+        return {
+            'left_bars': self.left_bars,
+            'right_bars': self.right_bars,
+            'min_amplitude_pct': self.min_amplitude_pct
+        }
+

--- a/bquant/analysis/zones/strategies/swing/thresholds.py
+++ b/bquant/analysis/zones/strategies/swing/thresholds.py
@@ -1,0 +1,64 @@
+"""Utilities for calculating adaptive swing thresholds."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class SwingThresholds:
+    """Container for dynamically computed swing thresholds."""
+
+    zigzag_deviation: float
+    peak_prominence: float
+    pivot_deviation: float
+
+
+def _safe_mid_price(close_series: pd.Series) -> Optional[float]:
+    """Calculate a stable mid-price value for a zone."""
+
+    if close_series.empty:
+        return None
+
+    median = close_series.median()
+    if pd.isna(median) or median == 0:
+        mean = close_series.mean()
+        if pd.isna(mean) or mean == 0:
+            return None
+        return float(mean)
+    return float(median)
+
+
+def auto_swing_thresholds(
+    zone_df: pd.DataFrame, *, base_deviation: float = 0.01
+) -> SwingThresholds:
+    """Scale swing thresholds based on the price range of a zone."""
+
+    if zone_df.empty:
+        return SwingThresholds(
+            zigzag_deviation=base_deviation,
+            peak_prominence=base_deviation,
+            pivot_deviation=base_deviation,
+        )
+
+    if not {"high", "low", "close"}.issubset(zone_df.columns):
+        raise KeyError("Zone dataframe must contain 'high', 'low', and 'close' columns")
+
+    price_range = float(zone_df["high"].max() - zone_df["low"].min())
+    mid_price = _safe_mid_price(zone_df["close"])
+
+    if not mid_price:
+        relative_range = base_deviation
+    else:
+        relative_range = price_range / mid_price
+
+    deviation = max(base_deviation, relative_range * 0.5)
+    prominence = max(base_deviation, relative_range * 0.3)
+    pivot_dev = max(base_deviation, relative_range * 0.25)
+
+    return SwingThresholds(
+        zigzag_deviation=deviation,
+        peak_prominence=prominence,
+        pivot_deviation=pivot_dev,
+    )

--- a/bquant/analysis/zones/strategies/swing/zigzag.py
+++ b/bquant/analysis/zones/strategies/swing/zigzag.py
@@ -335,3 +335,10 @@ class ZigZagSwingStrategy:
             ]
         }
 
+    def config_hash(self) -> Dict[str, Any]:
+        """Return configuration parameters for cache key generation."""
+        return {
+            'legs': self.legs,
+            'deviation': self.deviation
+        }
+

--- a/bquant/core/config.py
+++ b/bquant/core/config.py
@@ -1,12 +1,12 @@
-"""
-Configuration settings for the BQuant Project.
+"""Configuration settings for the BQuant Project.
 
 Universal configuration supporting multiple instruments, indicators, and analysis methods.
 """
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 # ============================================================================
 # PROJECT STRUCTURE
@@ -192,6 +192,51 @@ ANALYSIS_CONFIG = {
         'bootstrap_samples': 1000,
         'random_state': 42
     }
+}
+
+# ============================================================================
+# SWING STRATEGY PRESETS
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class SwingPreset:
+    """Grouping of parameter dictionaries for swing strategies."""
+
+    zigzag: Dict[str, Any]
+    find_peaks: Dict[str, Any]
+    pivot_points: Dict[str, Any]
+
+
+DEFAULT_SWING_PRESET = "default"
+
+SWING_PRESETS: Dict[str, SwingPreset] = {
+    DEFAULT_SWING_PRESET: SwingPreset(
+        zigzag={"legs": 10, "deviation": 0.05},
+        find_peaks={
+            "prominence": 0.015,
+            "distance": 5,
+            "min_amplitude_pct": 0.02,
+        },
+        pivot_points={
+            "left_bars": 2,
+            "right_bars": 2,
+            "min_amplitude_pct": 0.015,
+        },
+    ),
+    "narrow_zone": SwingPreset(
+        zigzag={"legs": 3, "deviation": 0.008},
+        find_peaks={
+            "prominence": 0.004,
+            "distance": 3,
+            "min_amplitude_pct": 0.006,
+        },
+        pivot_points={
+            "left_bars": 2,
+            "right_bars": 2,
+            "min_amplitude_pct": 0.006,
+        },
+    ),
 }
 
 # ============================================================================

--- a/devref/gaps/swing/README.md
+++ b/devref/gaps/swing/README.md
@@ -1,0 +1,52 @@
+# Swing strategy tuning checklist
+
+This reference collects the decisions made while restoring swing metrics and
+highlights the validation routine we expect to run after every adjustment.
+
+## Preset catalog
+
+| Preset | ZigZag | Find Peaks | Pivot Points | Typical usage |
+| --- | --- | --- | --- | --- |
+| `default` | `legs=10`, `deviation=0.05` | `prominence=0.015`, `distance=5`, `min_amplitude_pct=0.02` | `min_amplitude_pct=0.015`, `left/right_bars=2` | Matches historical behaviour. Use as the baseline export when comparing KPI deltas. |
+| `narrow_zone` | `legs=3`, `deviation=0.008` | `prominence=0.004`, `distance=3`, `min_amplitude_pct=0.006` | `min_amplitude_pct=0.006`, `left/right_bars=2` | Focuses on zones with price oscillations under 1 %. Expect swing density > 1.0 for `tv_xauusd_1h`. |
+
+Both presets live in `bquant/core/config.py` and are applied uniformly to the
+registered swing strategies through `ZoneAnalysisPipeline.with_swing_preset`.
+
+## KPI guard-rails
+
+* Target dataset: `tv_xauusd_1h` (TradingView extract bundled in
+  `bquant.data.samples`).
+* Success criteria: the mean number of swings per bull zone should stay above
+  1.0, with the tuned preset (`narrow_zone`) clustering around 55 swings for the
+  23 reference zones identified in the MACD zero-crossing workflow.
+* Cache must be disabled for interactive experiments to surface configuration
+  changes immediately.
+
+## Validation workflow
+
+1. Export the baseline metrics using the default preset:
+   ```bash
+   poetry run python research/notebooks/validate_swing_pivots.py \
+       --dataset tv_xauusd_1h \
+       --preset default \
+       --export outputs/reports/swing_default.json
+   ```
+   The command writes a JSON snapshot that contains the zone metadata, swing
+   metrics (via `SwingMetrics.to_dict()`), and pivot statistics for archival.
+2. Re-run the helper with the tuned preset and enforce pivot validation:
+   ```bash
+   poetry run python research/notebooks/validate_swing_pivots.py \
+       --dataset tv_xauusd_1h \
+       --preset narrow_zone \
+       --check \
+       --export outputs/reports/swing_narrow.json
+   ```
+   `--check` escalates any pivot ordering or range violations to a non-zero exit
+   status so CI picks up regressions.
+3. Compare the JSON exports (for example with `jq` or `meld`) and note the swing
+   density delta in the issue log. The tuned preset should report a materially
+   higher pivot count while keeping every point inside the original price band.
+
+Running these two commands after every tweak keeps the KPI history aligned with
+our empirical observations from `devref/gaps/swing/strat_issue.md`.

--- a/docs/analytics/zones/swing.md
+++ b/docs/analytics/zones/swing.md
@@ -1,0 +1,64 @@
+# Swing strategy configuration
+
+Swing metrics inside the zone analysis pipeline can now be tuned explicitly
+through presets or derived dynamically from the zone price range. This guide
+shows how to apply both options when orchestrating a run.
+
+## Applying a preset
+
+`bquant.core.config.SWING_PRESETS` bundles consistent parameter sets for the
+ZigZag, Find Peaks, and Pivot Points strategies. Use
+`ZoneAnalysisPipeline.with_swing_preset()` (or the builder shortcut) to deploy
+one of the presets across all swing components before triggering the analysis.
+
+```python
+from bquant.analysis.zones import analyze_zones
+from bquant.data.samples import get_sample_data
+
+df = get_sample_data("tv_xauusd_1h").set_index("time")
+
+result = (
+    analyze_zones(df)
+    .with_cache(enable=False)
+    .with_indicator("custom", "macd", fast_period=12, slow_period=26, signal_period=9)
+    .detect_zones("zero_crossing", indicator_col="macd_hist")
+    .with_strategies(swing="zigzag")
+    .with_swing_preset("narrow_zone")
+    .analyze(clustering=False)
+    .build()
+)
+
+bull_zones = [zone for zone in result.zones if zone.type == "bull"]
+print(bull_zones[0].features["metadata"]["swing_metrics"])  # preset parameters propagate here
+```
+
+The example above switches the pipeline to the `narrow_zone` preset, tightening
+ZigZag legs/deviation and the complementary thresholds so narrow bands register
+swing pivots.
+
+## Enabling adaptive thresholds
+
+When working with instruments that span a wide price range, enable adaptive
+thresholds to recompute ZigZag deviation and prominence values on a per-zone
+basis. The fluent builder exposes `.with_auto_swing_thresholds(True)` while the
+`ZoneAnalysisPipeline` constructor provides the underlying
+`strategy_auto_thresholds` flag.
+
+```python
+from bquant.analysis.zones.pipeline import ZoneAnalysisConfig, ZoneAnalysisPipeline
+
+pipeline = ZoneAnalysisPipeline(
+    config=my_config,
+    enable_cache=False,
+    strategy_auto_thresholds=True,
+    auto_threshold_base_deviation=0.01,
+)
+pipeline.with_swing_preset("default")  # optional baseline
+result = pipeline.run(df)
+```
+
+Adaptive mode falls back to the preset parameters whenever the computed range is
+smaller than `auto_threshold_base_deviation`, ensuring stability across thin
+zones. Combine the toggle with JSON exports from
+`research/notebooks/validate_swing_pivots.py` to compare KPI shifts before
+rolling the changes into production.

--- a/tests/analysis/zones/test_pipeline_cache.py
+++ b/tests/analysis/zones/test_pipeline_cache.py
@@ -1,0 +1,99 @@
+"""Tests for cache key generation and invalidation in the zone analysis pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+import pytest
+
+from bquant.analysis.zones.pipeline import (
+    IndicatorConfig,
+    ZoneAnalysisConfig,
+    ZoneAnalysisPipeline,
+)
+from bquant.analysis.zones.detection import ZoneDetectionConfig
+from bquant.data.samples import get_sample_data
+
+
+def _make_test_config() -> ZoneAnalysisConfig:
+    return ZoneAnalysisConfig(
+        indicator=IndicatorConfig(
+            source="custom",
+            name="macd",
+            params={"fast_period": 12, "slow_period": 26, "signal_period": 9},
+        ),
+        zone_detection=ZoneDetectionConfig(
+            min_duration=2,
+            zone_types=["bull"],
+            rules={"indicator_col": "macd_hist"},
+            strategy_name="zero_crossing",
+        ),
+        perform_clustering=False,
+        n_clusters=3,
+        run_regression=False,
+        run_validation=False,
+    )
+
+
+def _make_small_dataframe() -> pd.DataFrame:
+    data = {
+        "open": [1.0, 1.1, 1.2, 1.1, 1.0],
+        "high": [1.1, 1.2, 1.3, 1.2, 1.1],
+        "low": [0.9, 1.0, 1.1, 1.0, 0.9],
+        "close": [1.05, 1.15, 1.18, 1.12, 1.02],
+    }
+    return pd.DataFrame(data)
+
+
+def test_cache_key_changes_on_strategy_update() -> None:
+    df = _make_small_dataframe()
+    pipeline = ZoneAnalysisPipeline(_make_test_config(), enable_cache=True)
+
+    original_key = pipeline._generate_cache_key(df)
+
+    pipeline.swing_strategies["zigzag"].deviation = 0.02
+    pipeline._swing_preset_params["zigzag"]["deviation"] = 0.02
+
+    updated_key = pipeline._generate_cache_key(df)
+
+    assert original_key != updated_key
+
+
+class _RecordingCache:
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, str]] = []
+        self.storage: Dict[str, Any] = {}
+
+    def get(self, key: str) -> Any:
+        self.calls.append(("get", key))
+        return self.storage.get(key)
+
+    def put(self, key: str, value: Any, ttl: int | None = None, disk: bool = True) -> None:
+        self.calls.append(("put", key))
+        self.storage[key] = value
+
+    def invalidate(self, key: str) -> None:
+        self.calls.append(("invalidate", key))
+        self.storage.pop(key, None)
+
+
+@pytest.mark.slow
+def test_pipeline_recomputes_after_preset_switch() -> None:
+    df = get_sample_data("tv_xauusd_1h").set_index("time")
+
+    pipeline = ZoneAnalysisPipeline(_make_test_config(), enable_cache=True)
+    recording_cache = _RecordingCache()
+    pipeline.cache_manager = recording_cache
+
+    default_result = pipeline.run(df)
+
+    pipeline.with_swing_preset("narrow_zone")
+    narrow_result = pipeline.run(df)
+
+    get_calls = [key for action, key in recording_cache.calls if action == "get"]
+
+    assert len(get_calls) == 2
+    assert get_calls[0] != get_calls[1]
+    assert default_result is not narrow_result
+    assert len(recording_cache.storage) == 2

--- a/tests/analysis/zones/test_swing_presets.py
+++ b/tests/analysis/zones/test_swing_presets.py
@@ -1,0 +1,74 @@
+"""Integration tests for swing parameter presets in the zone pipeline."""
+
+from statistics import mean
+
+import pytest
+
+from bquant.analysis.zones.pipeline import (
+    IndicatorConfig,
+    ZoneAnalysisConfig,
+    ZoneAnalysisPipeline,
+)
+from bquant.analysis.zones.detection import ZoneDetectionConfig
+from bquant.core.config import SWING_PRESETS
+from bquant.data.samples import get_sample_data
+
+
+@pytest.mark.slow
+def test_narrow_zone_applies_parameters():
+    df = get_sample_data("tv_xauusd_1h").set_index("time")
+
+    config = ZoneAnalysisConfig(
+        indicator=IndicatorConfig(
+            source="custom",
+            name="macd",
+            params={"fast_period": 12, "slow_period": 26, "signal_period": 9},
+        ),
+        zone_detection=ZoneDetectionConfig(
+            min_duration=2,
+            zone_types=["bull"],
+            rules={"indicator_col": "macd_hist"},
+            strategy_name="zero_crossing",
+        ),
+        perform_clustering=False,
+        n_clusters=3,
+        run_regression=False,
+        run_validation=False,
+    )
+
+    pipeline = ZoneAnalysisPipeline(config, enable_cache=False)
+    pipeline.with_swing_preset("narrow_zone")
+
+    preset = SWING_PRESETS["narrow_zone"]
+    zigzag = pipeline.swing_strategies["zigzag"]
+    assert zigzag.legs == preset.zigzag["legs"]
+    assert zigzag.deviation == pytest.approx(preset.zigzag["deviation"])
+
+    find_peaks = pipeline.swing_strategies["find_peaks"]
+    assert find_peaks.prominence == pytest.approx(preset.find_peaks["prominence"])
+    assert find_peaks.distance == preset.find_peaks["distance"]
+    assert find_peaks.min_amplitude_pct == pytest.approx(
+        preset.find_peaks["min_amplitude_pct"]
+    )
+
+    pivot_points = pipeline.swing_strategies["pivot_points"]
+    assert pivot_points.min_amplitude_pct == pytest.approx(
+        preset.pivot_points["min_amplitude_pct"]
+    )
+
+    result = pipeline.run(df)
+    bull_zones = [zone for zone in result.zones if zone.type == "bull"]
+    assert bull_zones, "Expected bull zones to be present"
+
+    swing_counts = [
+        zone.features["metadata"]["swing_metrics"]["num_swings"]
+        for zone in bull_zones
+    ]
+    density = mean(swing_counts)
+    assert density > 1.0
+
+    sample_metrics = bull_zones[0].features["metadata"]["swing_metrics"]
+    assert sample_metrics["strategy_params"]["legs"] == preset.zigzag["legs"]
+    assert sample_metrics["strategy_params"]["deviation"] == pytest.approx(
+        preset.zigzag["deviation"]
+    )

--- a/tests/analysis/zones/test_swing_thresholds.py
+++ b/tests/analysis/zones/test_swing_thresholds.py
@@ -1,0 +1,96 @@
+"""Tests for adaptive swing threshold utilities and pipeline integration."""
+
+from statistics import mean
+
+import pandas as pd
+import pytest
+
+from bquant.analysis.zones.pipeline import (
+    IndicatorConfig,
+    ZoneAnalysisConfig,
+    ZoneAnalysisPipeline,
+)
+from bquant.analysis.zones.detection import ZoneDetectionConfig
+from bquant.analysis.zones.strategies.swing.thresholds import auto_swing_thresholds
+from bquant.core.config import SWING_PRESETS
+from bquant.data.samples import get_sample_data
+
+
+def test_auto_thresholds_scale_with_range() -> None:
+    narrow_base = pd.Series([100.0, 100.2, 100.3, 100.4, 100.1])
+    narrow_zone = pd.DataFrame(
+        {
+            "high": narrow_base + 0.1,
+            "low": narrow_base - 0.1,
+            "close": narrow_base,
+        }
+    )
+    wide_zone = pd.DataFrame(
+        {
+            "high": narrow_base + 5.0,
+            "low": narrow_base - 5.0,
+            "close": narrow_base + 2.5,
+        }
+    )
+
+    narrow_thresholds = auto_swing_thresholds(narrow_zone, base_deviation=0.01)
+    wide_thresholds = auto_swing_thresholds(wide_zone, base_deviation=0.01)
+
+    for value in (
+        narrow_thresholds.zigzag_deviation,
+        narrow_thresholds.peak_prominence,
+        narrow_thresholds.pivot_deviation,
+        wide_thresholds.zigzag_deviation,
+        wide_thresholds.peak_prominence,
+        wide_thresholds.pivot_deviation,
+    ):
+        assert value >= 0.01
+
+    assert wide_thresholds.zigzag_deviation > narrow_thresholds.zigzag_deviation
+    assert wide_thresholds.peak_prominence > narrow_thresholds.peak_prominence
+    assert wide_thresholds.pivot_deviation > narrow_thresholds.pivot_deviation
+
+
+@pytest.mark.slow
+def test_pipeline_auto_thresholds_matches_kpi() -> None:
+    df = get_sample_data("tv_xauusd_1h").set_index("time")
+
+    config = ZoneAnalysisConfig(
+        indicator=IndicatorConfig(
+            source="custom",
+            name="macd",
+            params={"fast_period": 12, "slow_period": 26, "signal_period": 9},
+        ),
+        zone_detection=ZoneDetectionConfig(
+            min_duration=2,
+            zone_types=["bull"],
+            rules={"indicator_col": "macd_hist"},
+            strategy_name="zero_crossing",
+        ),
+        perform_clustering=False,
+        n_clusters=3,
+        run_regression=False,
+        run_validation=False,
+    )
+
+    pipeline = ZoneAnalysisPipeline(
+        config,
+        enable_cache=False,
+        strategy_auto_thresholds=True,
+    )
+    pipeline.with_swing_preset("narrow_zone")
+    preset = SWING_PRESETS["narrow_zone"]
+
+    result = pipeline.run(df)
+    bull_zones = [zone for zone in result.zones if zone.type == "bull"]
+    assert bull_zones, "Expected bull zones when validating swing thresholds"
+
+    swing_counts = [
+        zone.features["metadata"]["swing_metrics"]["num_swings"]
+        for zone in bull_zones
+    ]
+    assert mean(swing_counts) > 1.0
+
+    sample_metrics = bull_zones[0].features["metadata"]["swing_metrics"]
+    assert sample_metrics["strategy_params"]["legs"] == preset.zigzag["legs"]
+    assert sample_metrics["strategy_params"]["deviation"] >= 0.01


### PR DESCRIPTION
## Summary
- add a developer reference that catalogs swing presets and documents the validation workflow for `tv_xauusd_1h`
- extend the analytics documentation with examples that use `with_swing_preset` and adaptive threshold toggles
- enhance `validate_swing_pivots.py` with preset-aware CLI options, JSON export support, and cache-safe pipeline wiring

## Testing
- poetry run python research/notebooks/validate_swing_pivots.py --dataset tv_xauusd_1h --preset default --export outputs/reports/swing_default.json *(fails: ModuleNotFoundError: No module named 'pandas')*
- poetry run python research/notebooks/validate_swing_pivots.py --dataset tv_xauusd_1h --preset narrow_zone --check --export outputs/reports/swing_narrow.json *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_690cadf35dd88322a0519f574768f630

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce swing strategy presets and per-zone adaptive thresholds with builder/pipeline APIs, update cache key to include swing config, extend validation tooling, and add tests/docs.
> 
> - **Pipeline (zones)**:
>   - Add swing presets application via `ZoneAnalysisPipeline.with_swing_preset()` and builder `.with_swing_preset()`.
>   - Introduce adaptive per-zone thresholds wrapper with `.with_auto_swing_thresholds()` and constructor flags; integrates with analyzer features.
>   - Cache key now uses `sha256` and includes serialized swing configuration via `_serialize_swing_configuration()`; add cache invalidation helper.
> - **Strategies**:
>   - Extend `SwingCalculationStrategy` protocol with `config_hash()`; implement in `zigzag`, `find_peaks`, `pivot_points`.
>   - Add `strategies/swing/thresholds.py` providing `auto_swing_thresholds()` and `SwingThresholds`.
> - **Config**:
>   - Add `SwingPreset` dataclass and `SWING_PRESETS` (incl. `default`, `narrow_zone`) with `DEFAULT_SWING_PRESET`.
> - **Research/Docs**:
>   - Enhance `research/notebooks/validate_swing_pivots.py` with preset/auto-threshold CLI, JSON export, and stricter checks.
>   - Add developer reference `devref/gaps/swing/README.md` and user docs `docs/analytics/zones/swing.md`.
> - **Tests**:
>   - Add tests for cache key sensitivity to swing config, preset application, and adaptive thresholds KPI checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0344bbc8ae385fa50763a761d1eac64abe1b4b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->