### PR TITLE
Add cloud diff probe marker to user guide

### DIFF
--- a/docs/user_guide/README.md
+++ b/docs/user_guide/README.md
@@ -138,3 +138,4 @@ pip install pandas numpy matplotlib seaborn plotly
 ---
 
 **Следующий шаг:** [Quick Start](quick_start.md) 🚀
+<!-- cloud diff probe (revertable) -->


### PR DESCRIPTION
## Summary
Added a revertable cloud diff probe marker to the end of the user guide README documentation.

## Changes
- Added HTML comment `<!-- cloud diff probe (revertable) -->` to `docs/user_guide/README.md` after the "Quick Start" link

## Details
This marker appears to be used for tracking or monitoring purposes in the documentation build/deployment pipeline. The `(revertable)` designation suggests this change can be safely reverted if needed.

https://claude.ai/code/session_01WfYuF6A7R8vg3TBXECS8ko