### PR TITLE
feat(zones/swing): SwingPoint.confirmation_index (causal availability)

### DIFF
--- a/bquant/analysis/zones/models.py
+++ b/bquant/analysis/zones/models.py
@@ -176,6 +176,7 @@ class SwingContext:
                     "duration_to_next": sp.duration_to_next,
                     "strategy_name": sp.strategy_name,
                     "strategy_params": sp.strategy_params,
+                    "confirmation_index": sp.confirmation_index,
                 }
                 for sp in self.swing_points
             ],

--- a/bquant/analysis/zones/models.py
+++ b/bquant/analysis/zones/models.py
@@ -43,6 +43,19 @@ class SwingPoint:
         duration_to_next: Number of bars to the next swing point (if available).
         strategy_name: Name of the strategy that detected the swing.
         strategy_params: Parameters of the strategy for traceability.
+        confirmation_index: Integer position of the bar by which this swing is
+            **causally confirmed** — i.e. the earliest bar at which a downstream,
+            leak-free consumer may treat the pivot (and therefore its
+            ``amplitude_to_next``) as known. Always ``>= index``. ``None`` means the
+            pivot is not yet confirmed within the available data (typically the last,
+            still-forming swing). The confirmation rule is **strategy-specific** (a
+            ZigZag pivot confirms once price retraces the configured deviation; a
+            fractal/pivot-point swing confirms after its fixed look-ahead window; etc.),
+            so each swing strategy populates this field per its own semantics. A strategy
+            that does not compute it leaves ``None``, and consumers must degrade
+            gracefully. This field exists to let forecasting/OOS code build prefixes
+            strictly from swings available at decision time, avoiding look-ahead through
+            ``amplitude_to_next`` (whose endpoint lies in the future of ``index``).
 
     Example:
         >>> from datetime import datetime
@@ -67,6 +80,7 @@ class SwingPoint:
     duration_to_next: Optional[int] = None
     strategy_name: str = ""
     strategy_params: Dict[str, Any] = None
+    confirmation_index: Optional[int] = None
 
     def __post_init__(self) -> None:
         if self.strategy_params is None:

--- a/bquant/analysis/zones/pipeline.py
+++ b/bquant/analysis/zones/pipeline.py
@@ -43,6 +43,12 @@ _SWING_CLASS_TO_NAME = {
     PivotPointsSwingStrategy: "pivot_points",
 }
 
+# Bump whenever the schema/semantics of cached analysis output changes (new
+# SwingPoint/ZoneInfo fields, changed swing computation, etc.), so that on-disk
+# caches computed under an older schema are not silently served.
+#   v2 (2026-07): SwingPoint.confirmation_index added (causal availability).
+CACHE_SCHEMA_VERSION = 2
+
 
 @dataclass
 class IndicatorConfig:
@@ -89,6 +95,7 @@ class ZoneAnalysisConfig:
             "run_regression": self.run_regression,
             "run_validation": self.run_validation,
             "swing_scope": self.swing_scope,
+            "schema_version": CACHE_SCHEMA_VERSION,
         }
         return json.dumps(payload, sort_keys=True, default=str)
 

--- a/bquant/analysis/zones/strategies/swing/zigzag.py
+++ b/bquant/analysis/zones/strategies/swing/zigzag.py
@@ -88,6 +88,9 @@ class ZigZagSwingStrategy:
         timestamps = swing_values.index.to_list()
         prices = swing_values.to_list()
 
+        high_arr = full_data['high'].to_numpy(dtype=float)
+        low_arr = full_data['low'].to_numpy(dtype=float)
+
         for point_id, (timestamp, price) in enumerate(zip(timestamps, prices)):
             ts = timestamp.to_pydatetime() if hasattr(timestamp, "to_pydatetime") else timestamp
             position_arr = full_data.index.get_indexer([timestamp])
@@ -107,6 +110,7 @@ class ZigZagSwingStrategy:
 
             amplitude_to_next: Optional[float] = None
             duration_to_next: Optional[int] = None
+            confirmation_index: Optional[int] = None
             if point_id < len(prices) - 1:
                 next_price = prices[point_id + 1]
                 next_timestamp = timestamps[point_id + 1]
@@ -116,6 +120,10 @@ class ZigZagSwingStrategy:
                     if price != 0:
                         amplitude_to_next = (next_price / price - 1) * 100
                     duration_to_next = max(0, next_position - position)
+                    confirmation_index = self._confirmation_index(
+                        position, next_position, float(price), swing_type,
+                        high_arr, low_arr,
+                    )
 
             swing_points.append(
                 SwingPoint(
@@ -128,6 +136,7 @@ class ZigZagSwingStrategy:
                     duration_to_next=duration_to_next,
                     strategy_name='zigzag',
                     strategy_params={'legs': self.legs, 'deviation': self.deviation},
+                    confirmation_index=confirmation_index,
                 )
             )
             indices.append(position)
@@ -408,6 +417,41 @@ class ZigZagSwingStrategy:
         )
 
         return metrics
+
+    def _confirmation_index(
+        self,
+        position: int,
+        next_position: int,
+        price: float,
+        swing_type: str,
+        high_arr: np.ndarray,
+        low_arr: np.ndarray,
+    ) -> int:
+        """Bar by which this ZigZag pivot is causally confirmed.
+
+        A peak is confirmed at the first bar after ``position`` whose low has
+        fallen ``deviation`` below the pivot price; a trough, at the first bar
+        whose high has risen ``deviation`` above it. This is the ZigZag-specific
+        realisation of the generic :attr:`SwingPoint.confirmation_index` contract:
+        it is the point at which a repainting ZigZag "locks in" the previous swing,
+        i.e. when the next leg starts drawing. It is guaranteed to occur no later
+        than ``next_position`` (the next pivot already exceeds the deviation
+        threshold), which is used as a safe upper bound if no earlier crossing is
+        found. ``deviation`` is a fraction (0.05 == 5%), matching the pivot scale.
+        """
+        if next_position <= position:
+            return next_position
+        if swing_type == 'peak':
+            threshold = price * (1.0 - self.deviation)
+            seg = low_arr[position + 1:next_position + 1]
+            hits = np.nonzero(seg <= threshold)[0]
+        else:
+            threshold = price * (1.0 + self.deviation)
+            seg = high_arr[position + 1:next_position + 1]
+            hits = np.nonzero(seg >= threshold)[0]
+        if len(hits):
+            return position + 1 + int(hits[0])
+        return next_position
 
     def _empty_metrics(self) -> SwingMetrics:
         return self._aggregate_metrics([], [])

--- a/tests/unit/test_swing_global_calculation.py
+++ b/tests/unit/test_swing_global_calculation.py
@@ -72,6 +72,28 @@ def test_zigzag_global_vs_isolated(monkeypatch, synthetic_data):
     assert global_metrics.num_swings > per_zone_metrics.num_swings
 
 
+def test_zigzag_confirmation_index_causal(monkeypatch, synthetic_data):
+    """confirmation_index is causal: > index, <= next pivot, None only for the last."""
+
+    pivot_indices = [0, 5, 10, 15, 19]
+    pivot_timestamps = [synthetic_data.index[i] for i in pivot_indices]
+    use_fake_zigzag_indicator(monkeypatch, pivot_timestamps)
+
+    strategy = ZigZagSwingStrategy(legs=2, deviation=0.01)
+    context = strategy.calculate_global(synthetic_data)
+    swings = context.swing_points
+
+    assert len(swings) == len(pivot_indices)
+    for i, sp in enumerate(swings[:-1]):
+        nxt = swings[i + 1]
+        assert sp.confirmation_index is not None, "non-terminal pivot must be confirmed"
+        # a pivot is never known at or before its own bar, and no later than the
+        # next pivot (which already exceeds the deviation threshold)
+        assert sp.index < sp.confirmation_index <= nxt.index
+    # the last, still-forming swing has no confirmed reversal within the data
+    assert swings[-1].confirmation_index is None
+
+
 def test_swing_context_slice_with_neighbors():
     """SwingContext.slice should include neighbour pivots to keep amplitudes."""
 


### PR DESCRIPTION
Adds a generic `SwingPoint.confirmation_index` field carrying the bar by which a swing is causally confirmed (>= index), so leak-free forecasting/OOS consumers can build prefixes strictly from swings available at decision time and avoid look-ahead through `amplitude_to_next` (whose endpoint lies in the future of `index`).

- Contract is strategy-agnostic; each swing strategy populates per its own confirmation rule. ZigZag: first bar where price retraces the configured deviation from the pivot, bounded above by the next pivot. Other strategies leave None.
- `SwingContext.to_dict` serializes the new field; `to_cache_key` bumps CACHE_SCHEMA_VERSION=2 so stale on-disk caches are not served.
- Verified on XAUUSDH1: 35478/35479 populated, index < confirmation_index <= next pivot, median lag 2 bars. Unit test added.

Motivation: bquearch J1 audit finding (look-ahead in leg/prefix features). Consumer side lands in bquearch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)