### PR TITLE
feat(zones/swing): confirmation_index for find_peaks & pivot_points

### DIFF
--- a/bquant/analysis/zones/pipeline.py
+++ b/bquant/analysis/zones/pipeline.py
@@ -47,7 +47,9 @@ _SWING_CLASS_TO_NAME = {
 # SwingPoint/ZoneInfo fields, changed swing computation, etc.), so that on-disk
 # caches computed under an older schema are not silently served.
 #   v2 (2026-07): SwingPoint.confirmation_index added (causal availability).
-CACHE_SCHEMA_VERSION = 2
+#   v3 (2026-07): confirmation_index now populated by find_peaks & pivot_points
+#                 (previously only zigzag; changes cached swing output).
+CACHE_SCHEMA_VERSION = 3
 
 
 @dataclass

--- a/bquant/analysis/zones/strategies/swing/find_peaks.py
+++ b/bquant/analysis/zones/strategies/swing/find_peaks.py
@@ -53,6 +53,10 @@ class FindPeaksSwingStrategy:
         swing_points: List[SwingPoint] = []
         indices: List[int] = []
 
+        high_arr = full_data['high'].to_numpy(dtype=float)
+        low_arr = full_data['low'].to_numpy(dtype=float)
+        full_len = len(full_data)
+
         for point_id, point in enumerate(extrema):
             timestamp = point['timestamp']
             ts = (
@@ -74,6 +78,16 @@ class FindPeaksSwingStrategy:
                     0, int(next_point['index']) - index_position
                 )
 
+            confirmation_index = self._confirmation_index(
+                index_position,
+                float(price),
+                point['type'],
+                prominence_value,
+                high_arr,
+                low_arr,
+                full_len,
+            )
+
             swing_points.append(
                 SwingPoint(
                     point_id=point_id,
@@ -85,6 +99,7 @@ class FindPeaksSwingStrategy:
                     duration_to_next=duration_to_next,
                     strategy_name='find_peaks',
                     strategy_params=self._build_strategy_params(prominence_value),
+                    confirmation_index=confirmation_index,
                 )
             )
             indices.append(index_position)
@@ -386,6 +401,52 @@ class FindPeaksSwingStrategy:
         )
 
         return metrics
+
+    def _confirmation_index(
+        self,
+        index: int,
+        price: float,
+        swing_type: str,
+        prominence: float,
+        high_arr: np.ndarray,
+        low_arr: np.ndarray,
+        full_len: int,
+    ) -> Optional[int]:
+        """Bar by which this find_peaks extremum is causally confirmed.
+
+        A find_peaks extremum survives the global pass only if it clears BOTH the
+        ``distance`` (minimum separation) and ``prominence`` filters. It becomes
+        causally known at the later of two events:
+
+        * **distance stabilisation** — ``index + distance``: once that many
+          right-hand bars are observed, no nearer higher peak (resp. lower trough)
+          can still displace it via the distance filter (had one existed within
+          ``distance``, the extremum would have been dropped, so its absence is
+          confirmed here);
+        * **prominence retrace** — the first bar after ``index`` at which the right
+          base falls ``prominence`` away from the pivot (peak: ``high <= price -
+          prominence``; trough: ``low >= price + prominence``). scipy's prominence
+          requires *both* bases below ``price - prominence``, so this right-side
+          retrace is a necessary condition and, for a kept extremum, occurs before
+          any higher opposing bar.
+
+        Returns ``max`` of the two (both are necessary), or ``None`` if the pivot
+        cannot yet be confirmed within the available data (retrace not reached, or
+        the distance window extends past the end — a still-forming tail swing).
+        This is the ``find_peaks`` realisation of the generic
+        :attr:`SwingPoint.confirmation_index` contract.
+        """
+        if swing_type == 'peak':
+            seg = high_arr[index + 1:]
+            hits = np.nonzero(seg <= price - prominence)[0]
+        else:
+            seg = low_arr[index + 1:]
+            hits = np.nonzero(seg >= price + prominence)[0]
+        if not len(hits):
+            return None
+        prominence_bar = index + 1 + int(hits[0])
+        conf = max(index + self.distance, prominence_bar)
+        return conf if conf < full_len else None
 
     def _empty_metrics(self) -> SwingMetrics:
         return self._aggregate_metrics(

--- a/bquant/analysis/zones/strategies/swing/pivot_points.py
+++ b/bquant/analysis/zones/strategies/swing/pivot_points.py
@@ -92,6 +92,10 @@ class PivotPointsSwingStrategy:
                     0, int(next_point['index']) - index_position
                 )
 
+            confirmation_index = self._confirmation_index(
+                index_position, len(full_data)
+            )
+
             swing_points.append(
                 SwingPoint(
                     point_id=point_id,
@@ -103,6 +107,7 @@ class PivotPointsSwingStrategy:
                     duration_to_next=duration_to_next,
                     strategy_name='pivot_points',
                     strategy_params=self._strategy_params(),
+                    confirmation_index=confirmation_index,
                 )
             )
             indices.append(index_position)
@@ -390,6 +395,24 @@ class PivotPointsSwingStrategy:
         )
 
         return metrics
+
+    def _confirmation_index(
+        self, index: int, full_data_length: int
+    ) -> Optional[int]:
+        """Bar by which this pivot is causally confirmed.
+
+        A classic N-bar pivot is defined by ``right_bars`` bars to its right that
+        are all lower (pivot high) or higher (pivot low). The pattern therefore
+        becomes complete — and the pivot causally known — exactly at
+        ``index + right_bars``: the bar at which the last required right-side bar
+        is observed. This is the ``pivot_points`` realisation of the generic
+        :attr:`SwingPoint.confirmation_index` contract (a fractal swing confirms
+        after its fixed right-hand look-ahead window). Because pivots are only
+        detected for ``index <= len - right_bars - 1``, the confirmation bar always
+        lies inside the data; the guard returns ``None`` only defensively.
+        """
+        conf = index + self.right_bars
+        return conf if conf < full_data_length else None
 
     def _empty_metrics(self) -> SwingMetrics:
         return self._aggregate_metrics([], [])

--- a/changelogs/CHANGE_TRACE_LOG_2026-07-20.md
+++ b/changelogs/CHANGE_TRACE_LOG_2026-07-20.md
@@ -1,0 +1,20 @@
+# Change Trace Log — 2026-07-20
+
+[17:24:00] [included] [Changed] Бамп версии пакета 0.0.1 → 0.0.2 в pyproject.toml (release под handoff из лабы bquearch)
+[17:24:30] [included] [Changed] Бамп __version__ 0.0.1 → 0.0.2 в bquant/__init__.py (версия хардкодится в двух местах)
+[17:25:00] [included] [Added] CHANGELOG.md: секция [0.0.2] - 2026-07-20 — Added SwingPoint.confirmation_index (causal availability, PR #107); Changed CACHE_SCHEMA_VERSION → 2
+[17:25:30] [included] [Technical] CHANGELOG.md: залежавшийся [Unreleased] переименован в [0.0.1] - 2026-01-12 (фактическое содержимое релиза 0.0.1, собранного в январе)
+[17:26:00] [included] [Technical] Прогон pytest: 730 passed, 12 skipped, 3 failed (3 фейла = известный гэп G7 в test_pandas_ta_dynamic_loader.py, пре-существующий, не блокирует)
+[17:29:00] [included] [Technical] Чистая сборка dist/bquant-0.0.2.{tar.gz,whl} (venv_bquant/bin/python -m build); twine check PASSED для обоих; confirmation_index присутствует в wheel
+[17:35:00] [included] [Files Modified] Коммит 3c95735 (pyproject.toml, bquant/__init__.py, CHANGELOG.md; submodule bquest не тронут) + аннотированный тег v0.0.2; пуш на origin (GitHub + GitLab)
+[17:43:00] [included] [Technical] ~/.pypirc переведён из dotenv-стиля в корректный INI ([pypi]/[testpypi], username=__token__), права 600, бэкап ~/.pypirc.dotenv.bak
+[17:50:00] [included] [Added] Публикация bquant 0.0.2 на боевой PyPI (twine upload); подтверждено: simple-индекс содержит оба файла, страница версии 200 — https://pypi.org/project/bquant/0.0.2/
+
+[18:12:00] [not_included] [Added] pivot_points: confirmation_index = index + right_bars — точное fractal-подтверждение (N-бар паттерн завершается ровно через right_bars); хелпер _confirmation_index в bquant/analysis/zones/strategies/swing/pivot_points.py
+[18:14:00] [not_included] [Added] find_peaks: confirmation_index = max(index + distance, бар prominence-ретрейса справа) — causal leak-free (оба условия необходимы для причинной детектируемости пика); хелпер _confirmation_index в bquant/analysis/zones/strategies/swing/find_peaks.py
+[18:15:00] [not_included] [Changed] CACHE_SCHEMA_VERSION 2 → 3 в bquant/analysis/zones/pipeline.py (find_peaks/pivot_points теперь заполняют confirmation_index — изменение семантики кэшируемого вывода, по инварианту handoff)
+[18:16:00] [not_included] [Technical] thresholds (_AdaptiveSwingStrategy) отдельной правки не требует — делегирует базовой стратегии в calculate_global, confirmation_index проходит насквозь (проверено на pivot_points/find_peaks)
+[18:17:00] [not_included] [Added] Тесты test_pivot_points_confirmation_index_fractal и test_find_peaks_confirmation_index_causal в tests/unit/test_swing_global_calculation.py (инварианты: index < conf < n, distance/right_bars как нижняя граница)
+[18:18:00] [not_included] [Technical] Sanity на tv_xauusd_1h: pivot_points 251/251 подтверждены (медианный лаг 2=right_bars), find_peaks 208/208 (медианный лаг 5=distance)
+
+==================== COMMIT DIVIDER ====================

--- a/tests/unit/test_swing_global_calculation.py
+++ b/tests/unit/test_swing_global_calculation.py
@@ -94,6 +94,42 @@ def test_zigzag_confirmation_index_causal(monkeypatch, synthetic_data):
     assert swings[-1].confirmation_index is None
 
 
+def test_pivot_points_confirmation_index_fractal(synthetic_data):
+    """pivot_points confirms exactly right_bars after the pivot (fixed window)."""
+
+    strategy = PivotPointsSwingStrategy(left_bars=2, right_bars=2)
+    context = strategy.calculate_global(synthetic_data)
+    swings = context.swing_points
+
+    assert len(swings) >= 2
+    n = context.full_data_length
+    for sp in swings:
+        # the N-bar pattern completes exactly right_bars later; always causal and
+        # inside the data (pivots are only detected for index <= n - right_bars - 1)
+        assert sp.confirmation_index == sp.index + strategy.right_bars
+        assert sp.index < sp.confirmation_index < n
+
+
+def test_find_peaks_confirmation_index_causal(synthetic_data):
+    """find_peaks confirmation is causal and respects the distance window."""
+
+    strategy = FindPeaksSwingStrategy(distance=3)
+    context = strategy.calculate_global(synthetic_data)
+    swings = context.swing_points
+
+    assert len(swings) >= 2
+    n = context.full_data_length
+    for sp in swings:
+        if sp.confirmation_index is None:
+            continue
+        # never known at/before its own bar; never past the data end
+        assert sp.index < sp.confirmation_index < n
+        # distance stabilisation is a lower bound on availability
+        assert sp.confirmation_index >= sp.index + strategy.distance
+    # on real sample data at least one non-tail extremum must confirm
+    assert any(sp.confirmation_index is not None for sp in swings)
+
+
 def test_swing_context_slice_with_neighbors():
     """SwingContext.slice should include neighbour pivots to keep amplitudes."""
 


### PR DESCRIPTION
Extends causal-availability marking (`SwingPoint.confirmation_index`, PR #107) from ZigZag to the two remaining swing strategies. Follow-up to the `bquant 0.0.2` release (handoff §4).

## What

- **`pivot_points`**: `confirmation_index = index + right_bars` — the N-bar fractal pattern completes exactly `right_bars` after the pivot; exact and always causal (pivots only exist for `index <= len - right_bars - 1`).
- **`find_peaks`**: `confirmation_index = max(index + distance, right-side prominence-retrace bar)` — both the distance-filter stabilisation and the prominence right-base are necessary conditions for the extremum to be causally detectable; leak-free.
- **`thresholds`** (`_AdaptiveSwingStrategy`): no change — delegates `calculate_global` to the base strategy, so the field passes through.
- **Cache**: `CACHE_SCHEMA_VERSION` 2 → 3 (cached swing output now carries populated `confirmation_index` for these strategies).

## Verification

- Sanity on `tv_xauusd_1h`: `pivot_points` 251/251 confirmed (median lag 2 = `right_bars`), `find_peaks` 208/208 (median lag 5 = `distance`).
- +2 invariant tests in `tests/unit/test_swing_global_calculation.py`.
- Full suite: **732 passed**, 12 skipped, 3 failed (pre-existing G7 in `test_pandas_ta_dynamic_loader.py`, unrelated).

Not published to PyPI — accumulating changes before the next release. The lab is not blocked (its consumer already uses a two-tier fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)